### PR TITLE
Migrate to digest 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["evpkdf", "openssl", "cryptography"]
 
 [dependencies]
-digest = "0.8.1"
+digest = "0.9.0"
 
 [dev-dependencies]
 hex-literal = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["evpkdf", "openssl", "cryptography"]
 digest = "0.9.0"
 
 [dev-dependencies]
-hex-literal = "0.2.1"
-md-5 = "0.8.0"
-sha-1 = "0.8.2"
+hex-literal = "0.3.3"
+md-5 = "0.9.1"
+sha-1 = "0.9.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,24 +89,24 @@ use digest::Digest;
 ///     &mut output
 /// );
 /// ```
-pub fn evpkdf<D: Digest>(pass: &[u8], salt: &[u8], count: usize, output: &mut [u8]) {
-    let mut hasher = D::new();
+pub fn evpkdf<D: Default + Digest>(pass: &[u8], salt: &[u8], count: usize, output: &mut [u8]) {
+    let mut hasher = D::default();
     let mut derived_key = Vec::with_capacity(output.len());
     let mut block = Vec::new();
 
     while derived_key.len() < output.len() {
         if !block.is_empty() {
-            hasher.input(block);
+            hasher.update(block);
         }
-        hasher.input(pass);
-        hasher.input(salt.as_ref());
-        block = hasher.result_reset().to_vec();
+        hasher.update(pass);
+        hasher.update(salt.as_ref());
+        block = hasher.finalize_reset().to_vec();
 
         // avoid subtract with overflow
         if count > 1 {
             for _ in 0..(count - 1) {
-                hasher.input(block);
-                block = hasher.result_reset().to_vec();
+                hasher.update(block);
+                block = hasher.finalize_reset().to_vec();
             }
         }
 


### PR DESCRIPTION
Digest changed its API in 0.9 to use IUF terminology (Initialize-Update-Finalize), so latest digest crate is incompatible with evpkdf. This pull request changes evpkdf to use digest 0.9.0 and its renamed function calls.

Dev dependencies are bumped as well to latest versions just to freshen things up; nothing should be broken.