### PR TITLE
Migrate to digest 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT"
 keywords = ["evpkdf", "openssl", "cryptography"]
 
 [dependencies]
-digest = "0.9"
+digest = "0.10"
 
 [dev-dependencies]
 hex-literal = "0.3"
-md-5 = "0.9"
-sha-1 = "0.9"
+md-5 = "0.10"
+sha-1 = "0.10"


### PR DESCRIPTION
It's that time of year again :) Digest changed its traits in 0.10 to further discern available functionality of an algorithm, so latest digest crate is incompatible with evpkdf. This pull request changes evpkdf to use digest 0.10 and its updated traits.